### PR TITLE
Added support for custom cache key provider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,147 @@
+####################################################################
+# Editor Configuration (Updated 2022-01-07)
+#
+# (c)2021 superdev GmbH
+####################################################################
+
+root = true
+
+[*.cs]
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_prefer_braces = true:error
+csharp_prefer_simple_default_expression = true:error
+csharp_prefer_simple_using_statement = false
+
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = none
+csharp_space_between_square_brackets = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_lambdas = true:none
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:silent
+
+csharp_style_conditional_delegate_call = true:error
+csharp_style_inlined_variable_declaration = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_throw_expression = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:error
+csharp_style_implicit_object_creation_when_type_is_apparent = false
+csharp_style_prefer_switch_expression = false
+
+dotnet_sort_system_directives_first = true
+dotnet_style_coalesce_expression = true:error
+dotnet_style_collection_initializer = true:error
+dotnet_style_explicit_tuple_names = true:error
+dotnet_style_null_propagation = true:error
+dotnet_style_object_initializer = true:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
+
+dotnet_style_qualification_for_event = true:error
+dotnet_style_qualification_for_field = true:error
+dotnet_style_qualification_for_method = true:error
+dotnet_style_qualification_for_property = true:error
+
+end_of_line = crlf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+tab_width = 4
+
+dotnet_naming_symbols.private_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.private_field_symbol.applicable_accessibilities = private
+dotnet_naming_style.private_field_style.capitalization = camel_case
+dotnet_naming_rule.private_fields_are_camel_case.severity = error
+dotnet_naming_rule.private_fields_are_camel_case.symbols = private_field_symbol
+dotnet_naming_rule.private_fields_are_camel_case.style = private_field_style
+
+dotnet_naming_symbols.non_private_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.non_private_field_symbol.applicable_accessibilities = public,internal,friend,protected,protected_internal,protected_friend
+dotnet_naming_style.non_private_field_style.capitalization = pascal_case
+dotnet_naming_rule.non_private_fields_are_pascal_case.severity = error
+dotnet_naming_rule.non_private_fields_are_pascal_case.symbols = non_private_field_symbol
+dotnet_naming_rule.non_private_fields_are_pascal_case.style = non_private_field_style
+
+dotnet_naming_symbols.parameter_symbol.applicable_kinds = parameter
+dotnet_naming_style.parameter_style.capitalization = camel_case
+dotnet_naming_rule.parameters_are_camel_case.severity = error
+dotnet_naming_rule.parameters_are_camel_case.symbols = parameter_symbol
+dotnet_naming_rule.parameters_are_camel_case.style = parameter_style
+
+dotnet_naming_symbols.non_interface_type_symbol.applicable_kinds = class,struct,enum,delegate
+dotnet_naming_style.non_interface_type_style.capitalization = pascal_case
+dotnet_naming_rule.non_interface_types_are_pascal_case.severity = error
+dotnet_naming_rule.non_interface_types_are_pascal_case.symbols = non_interface_type_symbol
+dotnet_naming_rule.non_interface_types_are_pascal_case.style = non_interface_type_style
+
+dotnet_naming_symbols.interface_type_symbol.applicable_kinds = interface
+dotnet_naming_style.interface_type_style.capitalization = pascal_case
+dotnet_naming_style.interface_type_style.required_prefix = I
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.severity = error
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.symbols = interface_type_symbol
+dotnet_naming_rule.interface_types_must_be_prefixed_with_I.style = interface_type_style
+
+dotnet_naming_symbols.member_symbol.applicable_kinds = method,property,event
+dotnet_naming_style.member_style.capitalization = pascal_case
+dotnet_naming_rule.members_are_pascal_case.severity = error
+dotnet_naming_rule.members_are_pascal_case.symbols = member_symbol
+dotnet_naming_rule.members_are_pascal_case.style = member_style
+
+dotnet_naming_rule.static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_pascal_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_pascal_case.style = static_field_style
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_style.static_field_style.capitalization = pascal_case
+
+# CS4014: Because this call is not awaited, execution of the current method continues before the call is completed
+dotnet_diagnostic.CS4014.severity = error
+
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = warning

--- a/HttpClient.Caching.sln
+++ b/HttpClient.Caching.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		build.yml = build.yml
 		README.md = README.md
+		.gitignore = .gitignore
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleAppSample", "Samples\ConsoleAppSample\ConsoleAppSample.csproj", "{592B2324-79AA-4973-8CE5-F65BD503641F}"

--- a/HttpClient.Caching/Abstractions/ICacheKeysProvider.cs
+++ b/HttpClient.Caching/Abstractions/ICacheKeysProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+
+namespace Microsoft.Extensions.Caching.Abstractions
+{
+    /// <summary>
+    ///     Provides keys to store or retrieve data in the cache
+    /// </summary>
+    public interface ICacheKeysProvider
+    {
+        /// <summary>
+        ///     Return the key for the request message <paramref name="request"/>
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        string GetKey(HttpRequestMessage request);
+    }
+}

--- a/HttpClient.Caching/HttpClient.Caching.csproj
+++ b/HttpClient.Caching/HttpClient.Caching.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.2;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.2;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>Thomas Galliker</Authors>
     <Company>superdev GmbH</Company>
     <Description>HttpClient.Caching adds http response caching to HttpClient.</Description>
-    <Copyright>Copyright 2021</Copyright>
+    <Copyright>Copyright 2022</Copyright>
     <PackageProjectUrl>https://github.com/thomasgalliker/HttpClient.Caching</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/thomasgalliker/HttpClient.Caching/master/logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/thomasgalliker/HttpClient.Caching</RepositoryUrl>
@@ -21,7 +21,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="[11.0.2,)" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.Caching.Abstractions;
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Text;
+using Microsoft.Extensions.Caching.Abstractions;
 
 namespace Microsoft.Extensions.Caching.InMemory
 {

--- a/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Caching.Abstractions;
 using System;
 using System.Net.Http;
+using System.Text;
 
 namespace Microsoft.Extensions.Caching.InMemory
 {
@@ -14,7 +15,9 @@ namespace Microsoft.Extensions.Caching.InMemory
         ///     with <see cref="HttpRequestMessage.Method"/> and <see cref="HttpRequestMessage.RequestUri"/>
         /// </summary>
         /// <param name="request"></param>
-        /// <returns></returns>
+        /// <returns>
+        ///     An example of return value: "MET_GET;URI_https://www.google.it"
+        /// </returns>
         public string GetKey(HttpRequestMessage request)
         {
             if (request is null)
@@ -22,9 +25,12 @@ namespace Microsoft.Extensions.Caching.InMemory
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var key = request.Method + request.RequestUri.ToString();
+            var sb = new StringBuilder();
 
-            return key;
+            sb.AppendFormat("MET_{0};", request.Method);
+            sb.AppendFormat("URI_{0};", request.RequestUri);
+
+            return sb.ToString();
         }
     }
 }

--- a/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/DefaultCacheKeysProvider.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Caching.Abstractions;
+using System;
+using System.Net.Http;
+
+namespace Microsoft.Extensions.Caching.InMemory
+{
+    /// <summary>
+    ///     Provides keys to store or retrieve data in the cache in the default way (http method + http request Uri)
+    /// </summary>
+    public class DefaultCacheKeysProvider : ICacheKeysProvider
+    {
+        /// <summary>
+        ///     Return the key for the request message <paramref name="request"/> by composing a string
+        ///     with <see cref="HttpRequestMessage.Method"/> and <see cref="HttpRequestMessage.RequestUri"/>
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public string GetKey(HttpRequestMessage request)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var key = request.Method + request.RequestUri.ToString();
+
+            return key;
+        }
+    }
+}

--- a/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.Caching.Abstractions;
-using System;
+﻿using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using Microsoft.Extensions.Caching.Abstractions;
 
 namespace Microsoft.Extensions.Caching.InMemory
 {
@@ -20,7 +20,9 @@ namespace Microsoft.Extensions.Caching.InMemory
         public MethodUriHeadersCacheKeysProvider(string[] headersName)
         {
             if (headersName != null)
+            {
                 this.headersName = headersName.OrderBy(i => i).ToArray();
+            }
         }
 
         /// <summary>
@@ -41,13 +43,13 @@ namespace Microsoft.Extensions.Caching.InMemory
             var sb = new StringBuilder();
 
             sb.AppendFormat("MET_{0};", request.Method);
-            if (headersName != null)
+            if (this.headersName != null)
             {
-                foreach (var headerName in headersName)
+                foreach (var headerName in this.headersName)
                 {
                     if (request.Headers.Contains(headerName))
                     {
-                        sb.AppendFormat("HEA_{0}_{1};", headerName, GetHeaderValue(request, headerName));
+                        sb.AppendFormat("HEA_{0}_{1};", headerName, this.GetHeaderValue(request, headerName));
                     }
                     else
                     {
@@ -73,14 +75,15 @@ namespace Microsoft.Extensions.Caching.InMemory
                 throw new ArgumentException($"'{nameof(headerName)}' cannot be null or empty.", nameof(headerName));
             }
 
-            string retVal = string.Empty;
+            var retVal = string.Empty;
 
             var headerValues = request.Headers.GetValues(headerName);
+            if (headerValues != null)
+            {
+                retVal = string.Join(",", headerValues.OrderBy(i => i));
+            }
 
-            if (headerValues == null)
-                return retVal;
-
-            return string.Join(",", headerValues.OrderBy(i => i));
+            return retVal;
         }
     }
 }

--- a/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Extensions.Caching.Abstractions;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace Microsoft.Extensions.Caching.InMemory
+{
+    /// <summary>
+    ///     Provides keys to store or retrieve data in the cache by using http method, specific headers and Uri
+    /// </summary>
+    public class MethodUriHeadersCacheKeysProvider : ICacheKeysProvider
+    {
+        private readonly string[] headersName;
+
+        /// <summary>
+        ///     Initialize the cache key provider passing the headers name that will be used to compose <paramref name="headersName"/>
+        /// </summary>
+        /// <param name="headersName"></param>
+        public MethodUriHeadersCacheKeysProvider(string[] headersName)
+        {
+            if (headersName != null)
+                this.headersName = headersName.OrderBy(i => i).ToArray();
+        }
+
+        /// <summary>
+        ///     Return the key for the request message <paramref name="request"/> by composing a string
+        ///     with <see cref="HttpRequestMessage.Method"/>, <see cref="HttpRequestMessage.Headers"/> and <see cref="HttpRequestMessage.RequestUri"/>
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns>
+        ///     An example of return value: "MET_GET;HEA_X-KID_389dfhuif;URI_https://www.google.it"
+        /// </returns>
+        public string GetKey(HttpRequestMessage request)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("MET_{0};", request.Method);
+            if (headersName != null)
+            {
+                foreach (var headerName in headersName)
+                {
+                    if (request.Headers.Contains(headerName))
+                    {
+                        sb.AppendFormat("HEA_{0}_{1};", headerName, GetHeaderValue(request, headerName));
+                    }
+                    else
+                    {
+                        sb.Append("HEA_;");
+                    }
+
+                }
+            }
+            sb.AppendFormat("URI_{0};", request.RequestUri);
+
+            return sb.ToString();
+        }
+
+        private string GetHeaderValue(HttpRequestMessage request, string headerName)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentException($"'{nameof(headerName)}' cannot be null or empty.", nameof(headerName));
+            }
+
+            string retVal = string.Empty;
+
+            var headerValues = request.Headers.GetValues(headerName);
+
+            if (headerValues == null)
+                return retVal;
+
+            return string.Join(",", headerValues.OrderBy(i => i));
+        }
+    }
+}

--- a/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
@@ -51,13 +51,9 @@ namespace Microsoft.Extensions.Caching.InMemory
                     {
                         sb.AppendFormat("HEA_{0}_{1};", headerName, this.GetHeaderValue(request, headerName));
                     }
-                    else
-                    {
-                        sb.Append("HEA_;");
-                    }
-
                 }
             }
+
             sb.AppendFormat("URI_{0};", request.RequestUri);
 
             return sb.ToString();
@@ -75,15 +71,15 @@ namespace Microsoft.Extensions.Caching.InMemory
                 throw new ArgumentException($"'{nameof(headerName)}' cannot be null or empty.", nameof(headerName));
             }
 
-            var retVal = string.Empty;
+            var orderedHeaderValues = string.Empty;
 
             var headerValues = request.Headers.GetValues(headerName);
             if (headerValues != null)
             {
-                retVal = string.Join(",", headerValues.OrderBy(i => i));
+                orderedHeaderValues = string.Join(",", headerValues.OrderBy(i => i));
             }
 
-            return retVal;
+            return orderedHeaderValues;
         }
     }
 }

--- a/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
+++ b/HttpClient.Caching/InMemory/MethodUriHeadersCacheKeysProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         /// </summary>
         /// <param name="request"></param>
         /// <returns>
-        ///     An example of return value: "MET_GET;HEA_X-KID_389dfhuif;URI_https://www.google.it"
+        ///     An example of return value: "MET_GET;HEA_X-KID_389dfhuif;URI_https://www.google.it?par1=65&par2=20;"
         /// </returns>
         public string GetKey(HttpRequestMessage request)
         {

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ TotalRequests: 5
 ### Cache keys
 
 By default, requests will be cached by using a key which is composed with http method and url (only HEAD and GET http methods are supported).
-If this default behavior isn't correct you can implement your own ICacheKeyProvider wich provides chache key starting from HttpRequestMessage.
+If this default behavior isn't enough **you can implement your own ICacheKeyProvider** wich provides **cache key** starting **from HttpRequestMessage**.
 
-The following example show how use a cache provider of type MethodUriHeadersCacheKeysProvider (evaluates http method, specified headers and url to compose a cache key)
+The following example show how use a cache provider of type MethodUriHeadersCacheKeysProvider.
+This cache key provider is already implemented and evaluates http method, specified headers and url to compose a cache key.
 with InMemoryCacheHandler.
 ```C#
 static void Main(string[] args)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,57 @@ TotalRequests: 5
 -> CacheMiss: 1
 ```
 
+### Cache keys
+
+By default, requests will be cached by using a key which is composed with http method and url (only HEAD and GET http methods are supported).
+If this default behavior isn't correct you can implement your own ICacheKeyProvider wich provides chache key starting from HttpRequestMessage.
+
+The following example show how use a cache provider of type MethodUriHeadersCacheKeysProvider (evaluates http method, specified headers and url to compose a cache key)
+with InMemoryCacheHandler.
+```C#
+static void Main(string[] args)
+{
+    const string url = "http://worldclockapi.com/api/json/utc/now";
+
+    var httpClientHandler = new HttpClientHandler();
+    var cacheExpirationPerHttpResponseCode = CacheExpirationProvider.CreateSimple(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
+    // this is a CacheKeyProvider which evaluates http method, specified headers and url to compose a key
+    var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "FIRST-HEADER", "SECOND-HEADER" });
+    var handler = new InMemoryCacheHandler(
+        innerHandler: httpClientHandler,
+        cacheExpirationPerHttpResponseCode: cacheExpirationPerHttpResponseCode,
+        cacheKeysProvider: cacheKeyProvider
+    );
+    
+    using (var client = new HttpClient(handler))
+    {
+        // HttpClient calls the same API endpoint five times:
+        // - The first attempt is called against the real API endpoint since no cache is available
+        // - Attempts 2 to 5 can be read from cache
+        for (var i = 1; i <= 5; i++)
+        {
+            Console.Write($"Attempt {i}: HTTP GET {url}...");
+            var stopwatch = Stopwatch.StartNew();
+            var result = client.GetAsync(url).GetAwaiter().GetResult();
+
+            // Do something useful with the returned content...
+            var content = result.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            Console.WriteLine($" completed in {stopwatch.ElapsedMilliseconds}ms");
+
+            // Artificial wait time...
+            Thread.Sleep(1000);
+        }
+    }
+
+    Console.WriteLine();
+
+    StatsResult stats = handler.StatsProvider.GetStatistics();
+    Console.WriteLine($"TotalRequests: {stats.Total.TotalRequests}");
+    Console.WriteLine($"-> CacheHit: {stats.Total.CacheHit}");
+    Console.WriteLine($"-> CacheMiss: {stats.Total.CacheMiss}");
+    Console.ReadKey();
+}
+```
 
 
 ### Further Reading

--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ static void Main(string[] args)
 [How-to: HTTP Caching for RESTful & Hypermedia APIs](https://www.apiacademy.co/articles/2015/12/how-to-http-caching-for-restful-hypermedia-apis)
 
 ### License
-This project is Copyright &copy; 2020 [Thomas Galliker](https://ch.linkedin.com/in/thomasgalliker). Free for non-commercial use. For commercial use please contact the author.
+This project is Copyright &copy; 2022 [Thomas Galliker](https://ch.linkedin.com/in/thomasgalliker). Free for non-commercial use. For commercial use please contact the author.

--- a/Samples/ConsoleAppSample/ConsoleAppSample.csproj
+++ b/Samples/ConsoleAppSample/ConsoleAppSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/WpfSample/App.config
+++ b/Samples/WpfSample/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.6.0" newVersion="2.0.6.0" />
+        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.6.0" newVersion="2.0.6.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Samples/WpfSample/Properties/Resources.Designer.cs
+++ b/Samples/WpfSample/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WpfSample.Properties
-{
-
-
+namespace WpfSample.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace WpfSample.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("WpfSample.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/Samples/WpfSample/Properties/Settings.Designer.cs
+++ b/Samples/WpfSample/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WpfSample.Properties
-{
-
-
+namespace WpfSample.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Samples/WpfSample/ViewModels/WeatherViewModel.cs
+++ b/Samples/WpfSample/ViewModels/WeatherViewModel.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
-using Tracing;
 using WpfSample.Model;
 using WpfSample.Services;
 
@@ -29,7 +27,7 @@ namespace WpfSample.ViewModels
             this.locationService = locationService;
             this.weatherService = weatherService;
 
-            this.LoadCurrentLocation();
+            _ = this.LoadCurrentLocation();
         }
 
         public ICommand GetCurrentLocationCommand =>

--- a/Samples/WpfSample/WpfSample.csproj
+++ b/Samples/WpfSample/WpfSample.csproj
@@ -8,12 +8,13 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WpfSample</RootNamespace>
     <AssemblyName>WpfSample</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Samples/WpfSample/packages.config
+++ b/Samples/WpfSample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="2.0.6" targetFramework="net47" />
+  <package id="CommonServiceLocator" version="2.0.6" targetFramework="net47" requireReinstallation="true" />
   <package id="MvvmLight" version="5.4.1.1" targetFramework="net47" />
   <package id="MvvmLightLibs" version="5.4.1.1" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net47" />

--- a/Tests/HttpClient.Caching.Tests/InMemory/DefaultCacheKeysProviderTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/DefaultCacheKeysProviderTests.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
-using HttpClient.Caching.Tests.Testdata;
 using Microsoft.Extensions.Caching.InMemory;
 using Xunit;
 

--- a/Tests/HttpClient.Caching.Tests/InMemory/DefaultCacheKeysProviderTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/DefaultCacheKeysProviderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HttpClient.Caching.Tests.Testdata;
+using Microsoft.Extensions.Caching.InMemory;
+using Xunit;
+
+namespace HttpClient.Caching.Tests.InMemory
+{
+    public class DefaultCacheKeysProviderTests
+    {
+        private readonly string url = "http://unittest/";
+
+        [Fact]
+        public void ShouldGetKey()
+        {
+            // Arrange
+            var cacheKeysProvider = new DefaultCacheKeysProvider();
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(this.url),
+                Method = HttpMethod.Get,
+            };
+
+            // Act
+            var cacheKey = cacheKeysProvider.GetKey(request);
+
+            // Assert
+            cacheKey.Should().Be("MET_GET;URI_http://unittest/;");
+        }
+    }
+}

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
@@ -34,7 +34,7 @@ namespace HttpClient.Caching.Tests.InMemory
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute twice
             await client.GetAsync("http://unittest");
@@ -51,7 +51,7 @@ namespace HttpClient.Caching.Tests.InMemory
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute for different URLs, only different by casing
             await client.GetAsync("http://unittest/foo.html");
@@ -67,7 +67,7 @@ namespace HttpClient.Caching.Tests.InMemory
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute for different URLs
             await client.GetAsync("http://unittest1");
@@ -83,7 +83,7 @@ namespace HttpClient.Caching.Tests.InMemory
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute twice for different methods
             await client.PostAsync("http://unittest", new StringContent(string.Empty));
@@ -102,7 +102,7 @@ namespace HttpClient.Caching.Tests.InMemory
         {
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute twice for different methods
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, "http://unittest"));
@@ -118,7 +118,7 @@ namespace HttpClient.Caching.Tests.InMemory
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
             // execute twice for different methods
             var originalResult = await client.GetAsync("http://unittest");

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
@@ -28,6 +28,8 @@ namespace HttpClient.Caching.Tests.InMemory
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
+        #region Tests with cache key provider MethodUriHeadersCacheKeysProvider
+
         /// <summary>
         /// By using <see cref="MethodUriHeadersCacheKeysProvider"/> without any header then <see cref="InMemoryCacheHandler"/> should
         /// behave like using <see cref="DefaultCacheKeysProvider"/>
@@ -268,6 +270,8 @@ namespace HttpClient.Caching.Tests.InMemory
             // assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
+
+        #endregion Tests with cache key provider MethodUriHeadersCacheKeysProvider
 
         [Fact]
         public async Task GetsTheDataAgainAfterEntryIsGoneFromCache()

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
@@ -28,17 +28,260 @@ namespace HttpClient.Caching.Tests.InMemory
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
+        /// <summary>
+        /// By using <see cref="MethodUriHeadersCacheKeysProvider"/> without any header then <see cref="InMemoryCacheHandler"/> should
+        /// behave like using <see cref="DefaultCacheKeysProvider"/>
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProvider()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            // no headers is provided so ICacheKeyProvider MethodUriHeadersCacheKeysProvider should behave like DefaultCacheKeysProvider
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(null);
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+
+            // execute twice
+            await client.GetAsync("http://unittest");
+            await client.GetAsync("http://unittest");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with custom headers, but requests don't specify any header
+        /// used by cache key provider
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_NoHeaders()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify different value for the header
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_DifferentValues()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value2");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// one request specify a value for the header, the other none doesn't specify any hader value
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_HeaderValueInOneRequest()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify same value for the header
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value1");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify same value for the headers
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            request1.Headers.Add("ANOTHER-HEADER", "Value2");
+            request1.Headers.Add("HEADER3", "Value3");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value1");
+            request2.Headers.Add("ANOTHER-HEADER", "Value2");
+            request2.Headers.Add("HEADER3", "Value3");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify same value for the headers that are common but not all specific request contains the same
+        /// headers
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders2()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            request1.Headers.Add("ANOTHER-HEADER", "Value2");
+            request1.Headers.Add("HEADER3", "Value3");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value1");
+            request2.Headers.Add("HEADER3", "Value3");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify same value for the headers but in different order
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders_DifferentOrder()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            request1.Headers.Add("HEADER3", "Value3");
+            request1.Headers.Add("ANOTHER-HEADER", "Value2");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value1");
+            request2.Headers.Add("ANOTHER-HEADER", "Value2");
+            request2.Headers.Add("HEADER3", "Value3");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        /// <summary>
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// both requests specify same value for specific header.
+        /// A request include some headers which aren't considered for cache key composition
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues2()
+        {
+            // arrange
+            var testMessageHandler = new TestMessageHandler();
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request1.Headers.Add("CUSTOM-HEADER", "Value1");
+            request1.Headers.Add("ANOTHER-CUSTOM-HEADER", "ValueX"); // this header isn't considered for cache key composition
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            request2.Headers.Add("CUSTOM-HEADER", "Value1");
+
+            // act
+            // execute twice
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // assert
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
         [Fact]
         public async Task GetsTheDataAgainAfterEntryIsGoneFromCache()
         {
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
+            var inMemoryCacheHandler = new InMemoryCacheHandler(testMessageHandler, null, null, cache, null);
+            var client = new System.Net.Http.HttpClient(inMemoryCacheHandler);
 
             // execute twice
             await client.GetAsync("http://unittest");
-            cache.Remove(HttpMethod.Get + new Uri("http://unittest").ToString());
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://unittest"));
+            cache.Remove(inMemoryCacheHandler.CacheKeysProvider.GetKey(request));
             await client.GetAsync("http://unittest");
 
             // validate

--- a/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
@@ -34,7 +34,7 @@ namespace HttpClient.Caching.Tests.InMemory
         public void ShouldGetKey_WithMatchingHeader()
         {
             // Arrange
-            var headersNames = new[] { "X-HEADER-1", "X-HEADER-2" };
+            var headersNames = new[] { "X-HEADER-2", "X-HEADER-1" };
             var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
             var request = new HttpRequestMessage
             {
@@ -47,14 +47,14 @@ namespace HttpClient.Caching.Tests.InMemory
             var cacheKey = cacheKeysProvider.GetKey(request);
 
             // Assert
-            cacheKey.Should().Be("MET_GET;HEA_X-HEADER-1_Value1;HEA_;URI_http://unittest/;");
+            cacheKey.Should().Be("MET_GET;HEA_X-HEADER-1_Value1;URI_http://unittest/;");
         }
         
         [Fact]
         public void ShouldGetKey_WithoutMatchingHeader()
         {
             // Arrange
-            var headersNames = new[] { "X-HEADER-1", "X-HEADER-2" };
+            var headersNames = new[] {  "X-HEADER-2", "X-HEADER-1" };
             var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
             var request = new HttpRequestMessage
             {
@@ -67,7 +67,7 @@ namespace HttpClient.Caching.Tests.InMemory
             var cacheKey = cacheKeysProvider.GetKey(request);
 
             // Assert
-            cacheKey.Should().Be("MET_GET;HEA_;HEA_;URI_http://unittest/;");
+            cacheKey.Should().Be("MET_GET;URI_http://unittest/;");
         }
     }
 }

--- a/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
-using HttpClient.Caching.Tests.Testdata;
 using Microsoft.Extensions.Caching.InMemory;
 using Xunit;
 
@@ -17,23 +11,63 @@ namespace HttpClient.Caching.Tests.InMemory
         private readonly string url = "http://unittest/";
 
         [Fact]
-        public void ShouldGetKey()
+        public void ShouldGetKey_EmptyHeaderNames()
         {
             // Arrange
-            var headersNames = new[] { "X-API-VERSION" };
+            var headersNames = new string[] { };
             var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
             var request = new HttpRequestMessage
             {
                 RequestUri = new Uri(this.url),
-                Method = HttpMethod.Get 
+                Method = HttpMethod.Get
             };
-            request.Headers.Add("X-API-VERSION", "v1");
+            request.Headers.Add("X-HEADER-1", "Value1");
 
             // Act
             var cacheKey = cacheKeysProvider.GetKey(request);
 
             // Assert
-            cacheKey.Should().Be("MET_GET;HEA_X-API-VERSION_v1;URI_http://unittest/;");
+            cacheKey.Should().Be("MET_GET;URI_http://unittest/;");
+        }
+
+        [Fact]
+        public void ShouldGetKey_WithMatchingHeader()
+        {
+            // Arrange
+            var headersNames = new[] { "X-HEADER-1", "X-HEADER-2" };
+            var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(this.url),
+                Method = HttpMethod.Get
+            };
+            request.Headers.Add("X-HEADER-1", "Value1");
+
+            // Act
+            var cacheKey = cacheKeysProvider.GetKey(request);
+
+            // Assert
+            cacheKey.Should().Be("MET_GET;HEA_X-HEADER-1_Value1;HEA_;URI_http://unittest/;");
+        }
+        
+        [Fact]
+        public void ShouldGetKey_WithoutMatchingHeader()
+        {
+            // Arrange
+            var headersNames = new[] { "X-HEADER-1", "X-HEADER-2" };
+            var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(this.url),
+                Method = HttpMethod.Get
+            };
+            request.Headers.Add("X-HEADER-3", "Value3");
+
+            // Act
+            var cacheKey = cacheKeysProvider.GetKey(request);
+
+            // Assert
+            cacheKey.Should().Be("MET_GET;HEA_;HEA_;URI_http://unittest/;");
         }
     }
 }

--- a/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/MethodUriHeadersCacheKeysProviderTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HttpClient.Caching.Tests.Testdata;
+using Microsoft.Extensions.Caching.InMemory;
+using Xunit;
+
+namespace HttpClient.Caching.Tests.InMemory
+{
+    public class MethodUriHeadersCacheKeysProviderTests
+    {
+        private readonly string url = "http://unittest/";
+
+        [Fact]
+        public void ShouldGetKey()
+        {
+            // Arrange
+            var headersNames = new[] { "X-API-VERSION" };
+            var cacheKeysProvider = new MethodUriHeadersCacheKeysProvider(headersNames);
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(this.url),
+                Method = HttpMethod.Get 
+            };
+            request.Headers.Add("X-API-VERSION", "v1");
+
+            // Act
+            var cacheKey = cacheKeysProvider.GetKey(request);
+
+            // Assert
+            cacheKey.Should().Be("MET_GET;HEA_X-API-VERSION_v1;URI_http://unittest/;");
+        }
+    }
+}

--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,7 @@
 ####################################################################
 # VSTS Build Configuration, Version 1.4
 #
-# (c)2021 superdev GmbH
+# (c)2022 superdev GmbH
 ####################################################################
 
 name: $[format('{0}', variables['buildName'])]


### PR DESCRIPTION
InMemoryCacheHandler now supports custom cache key provider.

**Custom cache key provider and already implemented cache key providers**
Interface ```ICacheKeysProvider``` allow to implement custom cache key providers.
Provider ```DefaultCacheKeysProvider``` provides cache key by concatenation of http method (GET or HEAD) and uri.
Provider ```MethodUriHeadersCacheKeysProvider``` provides cache key by concatenation of http method (GET or HEAD), specific  http headers and uri.

**Backward compatibility**
When no custom cache key provider is specified, InMemoryCacheHandler will use ```DefaultCacheKeysProvider``` which resemble previous cache key composition strategy: concatenation of http method (GET or HEAD) and uri. This allow backward compatibility.