### PR TITLE
Cache HttpClient.Send method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[Bug]"
+title: "[Bug] "
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Enhancement]"
+title: "[Enhancement] "
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,24 @@
+---
+name: Refactoring
+about: Internal changes to improve existing features 
+title: "[Refactoring] "
+labels: refactoring
+assignees: ''
+
+---
+
+### Description
+<!---
+A short description of the planned refactoring.
+--->
+
+### Background & Context
+<!---
+What is the motivation for the refactoring?
+Pros & cons, solutions and decisions concerning (reasoning) the refactoring.
+--->
+
+### References
+<!---
+Further references to e.g. other information resources like links to specification(s) etc.
+--->

--- a/HttpClient.Caching/Abstractions/CacheExtensions.cs
+++ b/HttpClient.Caching/Abstractions/CacheExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Caching.Abstractions
                 return true;
             }
 
-            value = default(TItem);
+            value = default;
             return false;
         }
 

--- a/HttpClient.Caching/InMemory/IMemoryCacheExtensions.cs
+++ b/HttpClient.Caching/InMemory/IMemoryCacheExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         /// <param name="cache">The in memory cache.</param>
         /// <param name="key">The key to retrieve from the cache.</param>
         /// <returns>The data of the cache entry, or null if not found or on any error.</returns>
+        [Obsolete("Use TryGetCacheData")]
         public static Task<CacheData> TryGetAsync(this IMemoryCache cache, string key)
         {
             try
@@ -31,6 +32,27 @@ namespace Microsoft.Extensions.Caching.InMemory
                 // ignore all exceptions; return null
                 return Task.FromResult(default(CacheData));
             }
+        }
+
+        public static bool TryGetCacheData(this IMemoryCache cache, string key, out CacheData cacheData)
+        {
+            var result = false;
+            cacheData = default;
+
+            try
+            {
+                if (cache.TryGetValue(key, out byte[] binaryData))
+                {
+                    cacheData = binaryData.Deserialize();
+                    result = true;
+                }
+            }
+            catch
+            {
+                // Ignore exception
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -53,6 +75,24 @@ namespace Microsoft.Extensions.Caching.InMemory
                 // ignore all exceptions
                 return Task.FromResult(false);
             }
+        }
+
+        public static bool TrySetCacheData(this IMemoryCache cache, string key, CacheData value, TimeSpan absoluteExpirationRelativeToNow)
+        {
+            var result = false;
+
+            try
+            {
+                cache.Set(key, value.Serialize(), absoluteExpirationRelativeToNow);
+                result = true;
+            }
+            catch
+            {
+                // Ignore exceptions
+                result = false;
+            }
+
+            return result;
         }
     }
 }

--- a/Samples/ConsoleAppSample/ConsoleAppSample.csproj
+++ b/Samples/ConsoleAppSample/ConsoleAppSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/ConsoleAppSample/Program.cs
+++ b/Samples/ConsoleAppSample/Program.cs
@@ -33,7 +33,12 @@ namespace ConsoleAppSample
                 {
                     Console.Write($"Attempt {i}: HTTP GET {url}...");
                     var stopwatch = Stopwatch.StartNew();
+
+                    // Send the http GET request using GetAsync
                     var httpResponseMessage = await httpClient.GetAsync(url);
+
+                    // Alternatively, use the Send or SendAsync methods to send the http request
+                    //var httpResponseMessage = httpClient.Send(new HttpRequestMessage(HttpMethod.Get, url));
 
                     // Do something useful with the returned content...
                     var httpResponseContent = await httpResponseMessage.Content.ReadAsStringAsync();

--- a/Samples/ConsoleAppSample/Program.cs
+++ b/Samples/ConsoleAppSample/Program.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Abstractions;
 using Microsoft.Extensions.Caching.InMemory;
 
@@ -9,15 +10,21 @@ namespace ConsoleAppSample
 {
     internal class Program
     {
-        private static void Main(string[] args)
+        private static async Task Main(string[] args)
         {
             const string url = "http://worldtimeapi.org/api/timezone/Europe/Zurich";
 
             // HttpClient uses an HttpClientHandler nested into InMemoryCacheHandler in order to handle http get response caching
             var httpClientHandler = new HttpClientHandler();
-            var cacheExpirationPerHttpResponseCode = CacheExpirationProvider.CreateSimple(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(5));
-            var handler = new InMemoryCacheHandler(httpClientHandler, cacheExpirationPerHttpResponseCode);
-            using (var client = new HttpClient(handler))
+
+            var cacheExpirationPerHttpResponseCode = CacheExpirationProvider.CreateSimple(
+                success: TimeSpan.FromSeconds(60),
+                clientError: TimeSpan.FromSeconds(10),
+                serverError: TimeSpan.FromSeconds(5));
+
+            var inMemoryCacheHandler = new InMemoryCacheHandler(httpClientHandler, cacheExpirationPerHttpResponseCode);
+
+            using (var httpClient = new HttpClient(inMemoryCacheHandler))
             {
                 // HttpClient calls the same API endpoint five times:
                 // - The first attempt is called against the real API endpoint since no cache is available
@@ -26,10 +33,10 @@ namespace ConsoleAppSample
                 {
                     Console.Write($"Attempt {i}: HTTP GET {url}...");
                     var stopwatch = Stopwatch.StartNew();
-                    var result = client.GetAsync(url).GetAwaiter().GetResult();
+                    var httpResponseMessage = await httpClient.GetAsync(url);
 
                     // Do something useful with the returned content...
-                    var content = result.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    var httpResponseContent = await httpResponseMessage.Content.ReadAsStringAsync();
                     Console.WriteLine($" completed in {stopwatch.ElapsedMilliseconds}ms");
 
                     // Artificial wait time...
@@ -39,8 +46,9 @@ namespace ConsoleAppSample
 
             Console.WriteLine();
 
-            var stats = handler.StatsProvider.GetStatistics();
-            Console.WriteLine($"TotalRequests: {stats.Total.TotalRequests}");
+            var stats = inMemoryCacheHandler.StatsProvider.GetStatistics();
+            Console.WriteLine($"Statistics:");
+            Console.WriteLine($"-> TotalRequests: {stats.Total.TotalRequests}");
             Console.WriteLine($"-> CacheHit: {stats.Total.CacheHit}");
             Console.WriteLine($"-> CacheMiss: {stats.Total.CacheMiss}");
             Console.ReadKey();

--- a/Tests/HttpClient.Caching.Tests/HttpClient.Caching.Tests.csproj
+++ b/Tests/HttpClient.Caching.Tests/HttpClient.Caching.Tests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.1">
+		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="ObjectDumper.NET" Version="4.1.15" />
-		<PackageReference Include="xunit" Version="2.7.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="ObjectDumper.NET" Version="4.2.7" />
+		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
@@ -28,6 +28,24 @@ namespace HttpClient.Caching.Tests.InMemory
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
+#if NET5_0_OR_GREATER
+        [Fact]
+        public void CachesTheResult_Send()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler));
+
+            // execute twice
+            var response1 = client.Send(new HttpRequestMessage(HttpMethod.Get, "http://unittest"));
+            var response2 = client.Send(new HttpRequestMessage(HttpMethod.Get, "http://unittest"));
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+            response1.Content.Should().BeEquivalentTo(response2.Content);
+        }
+#endif
+
         #region Tests with cache key provider MethodUriHeadersCacheKeysProvider
 
         /// <summary>

--- a/Tests/HttpClient.Caching.Tests/Testdata/TestMessageHandler.cs
+++ b/Tests/HttpClient.Caching.Tests/Testdata/TestMessageHandler.cs
@@ -21,7 +21,12 @@ namespace HttpClient.Caching.Tests.Testdata
 
         public int NumberOfCalls { get; set; }
 
-        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent, string contentType = DefaultContentType, Encoding encoding = null, TimeSpan delay = default(TimeSpan))
+        public TestMessageHandler(
+            HttpStatusCode responseStatusCode = DefaultResponseStatusCode,
+            string content = DefaultContent,
+            string contentType = DefaultContentType,
+            Encoding encoding = null,
+            TimeSpan delay = default)
         {
             this.responseStatusCode = responseStatusCode;
             this.content = content;
@@ -30,18 +35,39 @@ namespace HttpClient.Caching.Tests.Testdata
             this.encoding = encoding ?? Encoding.UTF8;
         }
 
+        private HttpResponseMessage CreateHttpResponseMessage()
+        {
+            return new HttpResponseMessage
+            {
+                Content = new StringContent(this.content, this.encoding, this.contentType),
+                StatusCode = this.responseStatusCode
+            };
+        }
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             this.NumberOfCalls++;
 
-            // optional delay
-            if (this.delay != default(TimeSpan))
+            if (this.delay != default)
             {
                 await Task.Delay(this.delay, cancellationToken);
             }
 
-            // simulate actual result
-            return new HttpResponseMessage { Content = new StringContent(this.content, this.encoding, this.contentType), StatusCode = this.responseStatusCode };
+            return this.CreateHttpResponseMessage();
         }
+
+#if NET5_0_OR_GREATER
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.NumberOfCalls++;
+
+            if (this.delay != default)
+            {
+                Thread.Sleep(this.delay);
+            }
+
+            return this.CreateHttpResponseMessage();
+        }
+#endif
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   majorVersion: 1
-  minorVersion: 4
+  minorVersion: 5
   patchVersion: $[counter(format('{0}.{1}', variables.majorVersion, variables.minorVersion), 0)]
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     # Versioning: 1.0.0


### PR DESCRIPTION
Following method call should now be cached using `InMemoryCacheHandler`. 
`var httpResponseMessage = httpClient.Send(new HttpRequestMessage(HttpMethod.Get, url));`