### PR TITLE
Better control of caching logic by following headers and a manual option to turn of caching for a request

### DIFF
--- a/HttpClient.Caching/InMemory/InMemoryCacheHandler.cs
+++ b/HttpClient.Caching/InMemory/InMemoryCacheHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         ///   If the key is present and the value is false, the cache will not be checked.
         ///   If the key is present and the value is true, the cache will be checked.
         /// </summary>
-        public readonly static HttpRequestOptionsKey<bool> UseCache = new("UseCache");
+        public readonly static HttpRequestOptionsKey<bool> UseCache = new(nameof(UseCache));
 #else
         /// <summary>
         ///   The key to use to store the UseCache value in the HttpRequestMessage.Properties dictionary.
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         ///   If the key is present and the value is false, the cache will not be checked.
         ///   If the key is present and the value is true, the cache will be checked.
         /// </summary>
-        public const string UseCache = "UseCache";
+        public const string UseCache = nameof(UseCache);
         #endif
 
         private static HashSet<HttpMethod> CachedHttpMethods = new HashSet<HttpMethod>

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -16,15 +17,15 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task CachesTheResult()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler));
 
-            // execute twice
+            // Act
             await client.GetAsync("http://unittest");
             await client.GetAsync("http://unittest");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
@@ -32,15 +33,15 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public void CachesTheResult_Send()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler));
 
-            // execute twice
+            // Act
             var response1 = client.Send(new HttpRequestMessage(HttpMethod.Get, "http://unittest"));
             var response2 = client.Send(new HttpRequestMessage(HttpMethod.Get, "http://unittest"));
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
             response1.Content.Should().BeEquivalentTo(response2.Content);
         }
@@ -56,17 +57,17 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProvider()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
-            // no headers is provided so ICacheKeyProvider MethodUriHeadersCacheKeysProvider should behave like DefaultCacheKeysProvider
+            // no headers are provided so ICacheKeyProvider MethodUriHeadersCacheKeysProvider should behave like DefaultCacheKeysProvider
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(null);
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
 
-            // execute twice
+            // Act
             await client.GetAsync("http://unittest");
             await client.GetAsync("http://unittest");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
@@ -74,35 +75,33 @@ namespace HttpClient.Caching.Tests.InMemory
         /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with custom headers, but requests don't specify any header
         /// used by cache key provider
         /// </summary>
-        /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_NoHeaders()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
             var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
             var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify different value for the header
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_DifferentValues()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -111,24 +110,23 @@ namespace HttpClient.Caching.Tests.InMemory
             var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
             request2.Headers.Add("CUSTOM-HEADER", "Value2");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// one request specify a value for the header, the other none doesn't specify any hader value
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_HeaderValueInOneRequest()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -136,24 +134,23 @@ namespace HttpClient.Caching.Tests.InMemory
             request1.Headers.Add("CUSTOM-HEADER", "Value1");
             var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify same value for the header
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -162,24 +159,23 @@ namespace HttpClient.Caching.Tests.InMemory
             var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
             request2.Headers.Add("CUSTOM-HEADER", "Value1");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify same value for the headers
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -192,17 +188,16 @@ namespace HttpClient.Caching.Tests.InMemory
             request2.Headers.Add("ANOTHER-HEADER", "Value2");
             request2.Headers.Add("HEADER3", "Value3");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify same value for the headers that are common but not all specific request contains the same
         /// headers
         /// </summary>
@@ -210,7 +205,7 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders2()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -222,24 +217,23 @@ namespace HttpClient.Caching.Tests.InMemory
             request2.Headers.Add("CUSTOM-HEADER", "Value1");
             request2.Headers.Add("HEADER3", "Value3");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify same value for the headers but in different order
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues_MultipleHeaders_DifferentOrder()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER", "ANOTHER-HEADER", "HEADER3" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
@@ -252,17 +246,16 @@ namespace HttpClient.Caching.Tests.InMemory
             request2.Headers.Add("ANOTHER-HEADER", "Value2");
             request2.Headers.Add("HEADER3", "Value3");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
         /// <summary>
-        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers, 
+        /// <see cref="InMemoryCacheHandler"/> use <see cref="MethodUriHeadersCacheKeysProvider"/> with specific headers,
         /// both requests specify same value for specific header.
         /// A request include some headers which aren't considered for cache key composition
         /// </summary>
@@ -270,9 +263,9 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task CachesTheResult_MethodUriHeadersCacheKeysProviderWithCustomHeaders_SameValues2()
         {
-            // arrange
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
-            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new string[] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
+            var cacheKeyProvider = new MethodUriHeadersCacheKeysProvider(new [] { "CUSTOM-HEADER" }); //this is the header that will be included in cache key generator
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheKeysProvider: cacheKeyProvider));
             var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
             request1.Headers.Add("CUSTOM-HEADER", "Value1");
@@ -280,12 +273,11 @@ namespace HttpClient.Caching.Tests.InMemory
             var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
             request2.Headers.Add("CUSTOM-HEADER", "Value1");
 
-            // act
-            // execute twice
+            // Act
             await client.SendAsync(request1);
             await client.SendAsync(request2);
 
-            // assert
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(1);
         }
 
@@ -294,63 +286,83 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task GetsTheDataAgainAfterEntryIsGoneFromCache()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var inMemoryCacheHandler = new InMemoryCacheHandler(testMessageHandler, null, null, cache, null);
             var client = new System.Net.Http.HttpClient(inMemoryCacheHandler);
 
-            // execute twice
+            // Act
             await client.GetAsync("http://unittest");
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri("http://unittest"));
             cache.Remove(inMemoryCacheHandler.CacheKeysProvider.GetKey(request));
             await client.GetAsync("http://unittest");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task IsCaseSensitive()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
-            // execute for different URLs, only different by casing
+            // Act for different URLs, only different by casing
             await client.GetAsync("http://unittest/foo.html");
             await client.GetAsync("http://unittest/FOO.html");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task CachesPerUrl()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
-            // execute for different URLs
+            // Act for different URLs
             await client.GetAsync("http://unittest1");
             await client.GetAsync("http://unittest2");
 
-            // validate
+            // Assert
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task CachesWithCacheControlHeaders_NoCacheTrue()
+        {
+            // Arrange
+            var cacheControl = new CacheControlHeaderValue{ NoCache = true, NoStore = true };
+            var testMessageHandler = new TestMessageHandler(cacheControl: cacheControl);
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
+
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "http://unittest");
+
+            // Act for different URLs
+            await client.SendAsync(request1);
+            await client.SendAsync(request2);
+
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task OnlyCachesGetAndHeadResults()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
-            // execute twice for different methods
+            // Act for different methods
             await client.PostAsync("http://unittest", new StringContent(string.Empty));
             await client.PostAsync("http://unittest", new StringContent(string.Empty));
             await client.PutAsync("http://unittest", new StringContent(string.Empty));
@@ -358,40 +370,41 @@ namespace HttpClient.Caching.Tests.InMemory
             await client.DeleteAsync("http://unittest");
             await client.DeleteAsync("http://unittest");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(6);
         }
 
         [Fact]
         public async Task CachesHeadAndGetRequestWithoutConflict()
         {
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
-            // execute twice for different methods
+            // Act for different methods
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, "http://unittest"));
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://unittest"));
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task DataFromCallMatchesDataFromCache()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, null, null, cache, null));
 
-            // execute twice for different methods
+            // Act for different methods
             var originalResult = await client.GetAsync("http://unittest");
             var cachedResult = await client.GetAsync("http://unittest");
             var originalResultString = await originalResult.Content.ReadAsStringAsync();
             var cachedResultString = await cachedResult.Content.ReadAsStringAsync();
 
-            // validate
+            // Assert
             originalResultString.Should().BeEquivalentTo(cachedResultString);
             originalResultString.Should().BeEquivalentTo(TestMessageHandler.DefaultContent);
         }
@@ -399,14 +412,14 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task ReturnsResponseHeader()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler(HttpStatusCode.OK, "test content", "text/plain", Encoding.UTF8);
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler));
 
-            // execute 
+            // Act
             var response = await client.GetAsync("http://unittest");
 
-            // validate
+            // Assert
             response.Content.Headers.ContentType.MediaType.Should().Be("text/plain");
             response.Content.Headers.ContentType.CharSet.Should().Be("utf-8");
         }
@@ -414,7 +427,7 @@ namespace HttpClient.Caching.Tests.InMemory
         [Fact]
         public async Task DisableCachePerStatusCode()
         {
-            // setup
+            // Arrange
             var cacheExpirationPerStatusCode = new Dictionary<HttpStatusCode, TimeSpan>
             {
                 { (HttpStatusCode)200, TimeSpan.FromSeconds(0) }
@@ -423,41 +436,41 @@ namespace HttpClient.Caching.Tests.InMemory
             var testMessageHandler = new TestMessageHandler();
             var client = new System.Net.Http.HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheExpirationPerStatusCode));
 
-            // execute twice
+            // Act
             await client.GetAsync("http://unittest");
             await client.GetAsync("http://unittest");
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task InvalidatesCacheCorrectly()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var handler = new InMemoryCacheHandler(testMessageHandler);
             var client = new System.Net.Http.HttpClient(handler);
 
-            // execute twice, with cache invalidation in between
+            // Act, with cache invalidation in between
             var uri = new Uri("http://unittest");
             await client.GetAsync(uri);
             handler.InvalidateCache(uri);
             await client.GetAsync(uri);
 
-            // validate
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(2);
         }
 
         [Fact]
         public async Task InvalidatesCachePerMethod()
         {
-            // setup
+            // Arrange
             var testMessageHandler = new TestMessageHandler();
             var handler = new InMemoryCacheHandler(testMessageHandler);
             var client = new System.Net.Http.HttpClient(handler);
 
-            // execute with two methods, and clean up one cache
+            // Act with two methods, and clean up one cache
             var uri = new Uri("http://unittest");
             await client.GetAsync(uri);
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri));
@@ -466,9 +479,11 @@ namespace HttpClient.Caching.Tests.InMemory
             // clean cache
             handler.InvalidateCache(uri, HttpMethod.Head);
 
-            // execute both actions, and only one should be retrieved from cache
+            // Act both actions, and only one should be retrieved from cache
             await client.GetAsync(uri);
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri));
+
+            // Assert
             testMessageHandler.NumberOfCalls.Should().Be(3);
         }
     }

--- a/Tests/HttpClient.Caching.Tests/Testdata/TestMessageHandler.cs
+++ b/Tests/HttpClient.Caching.Tests/Testdata/TestMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ namespace HttpClient.Caching.Tests.Testdata
         private readonly string content;
         private readonly string contentType;
         private readonly TimeSpan delay;
+        private readonly CacheControlHeaderValue cacheControl;
         private readonly Encoding encoding;
 
         public int NumberOfCalls { get; set; }
@@ -26,22 +28,31 @@ namespace HttpClient.Caching.Tests.Testdata
             string content = DefaultContent,
             string contentType = DefaultContentType,
             Encoding encoding = null,
-            TimeSpan delay = default)
+            TimeSpan delay = default,
+            CacheControlHeaderValue cacheControl = null)
         {
             this.responseStatusCode = responseStatusCode;
             this.content = content;
             this.contentType = contentType;
             this.delay = delay;
+            this.cacheControl = cacheControl;
             this.encoding = encoding ?? Encoding.UTF8;
         }
 
         private HttpResponseMessage CreateHttpResponseMessage()
         {
-            return new HttpResponseMessage
+            var httpResponseMessage = new HttpResponseMessage
             {
                 Content = new StringContent(this.content, this.encoding, this.contentType),
-                StatusCode = this.responseStatusCode
+                StatusCode = this.responseStatusCode,
             };
+
+            if (this.cacheControl != null)
+            {
+                httpResponseMessage.Headers.CacheControl = this.cacheControl;
+            }
+
+            return httpResponseMessage;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
This PR adds support for better control of what is cached and when - first of, using `HttpRequestMessage.Properties/Options` with a specific key allows one to disable checking the cache for a request. It also follows the `Cache-Control` headers from the server, including the `max-age` if it's lower than the specified cache time.

Issue: https://github.com/thomasgalliker/HttpClient.Caching/issues/18