### PR TITLE
Merge evaluate-replacing-custom-inmemory-cache into develop

### DIFF
--- a/HttpClient.Caching/InMemory/InMemoryCacheFallbackHandler.cs
+++ b/HttpClient.Caching/InMemory/InMemoryCacheFallbackHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         public IStatsProvider StatsProvider { get; }
         private readonly TimeSpan maxTimeout;
         private readonly TimeSpan cacheDuration;
-        private readonly IMemoryCache responseCache;
+        private readonly MemoryCache responseCache;
         internal const string CacheFallbackKeyPrefix = "cfb";
 
         /// <summary>
@@ -28,8 +28,8 @@ namespace Microsoft.Extensions.Caching.InMemory
         ///     An <see cref="IStatsProvider" /> that records statistic information about the caching
         ///     behavior.
         /// </param>
-        public InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider = null)
-            : this(innerHandler, maxTimeout, cacheDuration, statsProvider, new MemoryCache(new MemoryCacheOptions()))
+        public InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider = null, MemoryCacheOptions memoryCacheOptions = null)
+            : this(innerHandler, maxTimeout, cacheDuration, statsProvider, new MemoryCache(memoryCacheOptions ?? new MemoryCacheOptions()))
         {
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         ///     behavior.
         /// </param>
         /// <param name="cache">The cache to be used.</param>
-        internal InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider, IMemoryCache cache) : base(innerHandler ?? new HttpClientHandler())
+        internal InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider, MemoryCache cache) : base(innerHandler ?? new HttpClientHandler())
         {
             this.StatsProvider = statsProvider ?? new StatsProvider(nameof(InMemoryCacheHandler));
             this.maxTimeout = maxTimeout;

--- a/HttpClient.Caching/InMemory/InMemoryCacheHandler.cs
+++ b/HttpClient.Caching/InMemory/InMemoryCacheHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Caching.InMemory
         public IStatsProvider StatsProvider { get; }
 
         private readonly IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode;
-        private readonly IMemoryCache responseCache;
+        private readonly MemoryCache responseCache;
 
         /// <summary>
         /// Cache key provider being used
@@ -69,11 +69,12 @@ namespace Microsoft.Extensions.Caching.InMemory
         public InMemoryCacheHandler(HttpMessageHandler innerHandler = null,
             IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode = null,
             IStatsProvider statsProvider = null,
-            ICacheKeysProvider cacheKeysProvider = null)
+            ICacheKeysProvider cacheKeysProvider = null,
+            MemoryCacheOptions memoryCacheOptions = null)
             : this(innerHandler,
                 cacheExpirationPerHttpResponseCode,
                 statsProvider,
-                new MemoryCache(new MemoryCacheOptions()),
+                new MemoryCache(memoryCacheOptions ?? new MemoryCacheOptions()),
                 cacheKeysProvider)
         {
         }
@@ -96,7 +97,7 @@ namespace Microsoft.Extensions.Caching.InMemory
             HttpMessageHandler innerHandler,
             IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode,
             IStatsProvider statsProvider,
-            IMemoryCache cache,
+            MemoryCache cache,
             ICacheKeysProvider cacheKeysProvider)
             : base(innerHandler ?? new HttpClientHandler())
         {

--- a/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheFallbackHandlerTests.cs
+++ b/Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheFallbackHandlerTests.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 using HttpClient.Caching.Tests.Testdata;
 using Microsoft.Extensions.Caching.Abstractions;
 using Microsoft.Extensions.Caching.InMemory;
-using Moq;
 using Xunit;
 
 namespace HttpClient.Caching.Tests.InMemory
@@ -37,16 +36,16 @@ namespace HttpClient.Caching.Tests.InMemory
         {
             // setup
             var testMessageHandler = new TestMessageHandler();
-            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cache = new MemoryCache(new MemoryCacheOptions());
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url));
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache));
+            var key = InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url;
 
-            // execute twice, validate cache is called each time
+            // execute twice and validate cache is updated each time
             await client.GetAsync(this.url);
-            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url), Times.Once);
+            cache.Get(key).Should().NotBeNull();
             await client.GetAsync(this.url);
-            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url), Times.Exactly(2));
+            cache.Get(key).Should().NotBeNull();
         }
 
         [Fact]
@@ -54,17 +53,17 @@ namespace HttpClient.Caching.Tests.InMemory
         {
             // setup
             var testMessageHandler = new TestMessageHandler();
-            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cache = new MemoryCache(new MemoryCacheOptions());
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url));
-            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Head + this.url));
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache));
+            var getKey = InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url;
+            var headKey = InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Head + this.url;
 
-            // execute twice, validate cache is called each time
+            // execute and validate cache entries for both methods are created
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, this.url));
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, this.url));
-            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Head + this.url), Times.Once);
-            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url), Times.Once);
+            cache.Get(headKey).Should().NotBeNull();
+            cache.Get(getKey).Should().NotBeNull();
         }
 
         [Fact]
@@ -72,18 +71,16 @@ namespace HttpClient.Caching.Tests.InMemory
         {
             // setup
             var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
-            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cache = new MemoryCache(new MemoryCacheOptions());
             var cacheTime = TimeSpan.FromSeconds(123);
-            object expectedValue;
-            cache.Setup(c => c.CreateEntry(It.IsAny<string>()));
-            cache.Setup(c => c.TryGetValue(this.url, out expectedValue)).Returns(false);
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache));
+            var key = InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + this.url;
 
             // execute
             await client.GetAsync(this.url);
 
             // validate
-            cache.Verify(c => c.CreateEntry(It.IsAny<string>()), Times.Never);
+            cache.Get(key).Should().BeNull();
         }
 
         [Fact]
@@ -91,11 +88,9 @@ namespace HttpClient.Caching.Tests.InMemory
         {
             // setup
             var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
-            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cache = new MemoryCache(new MemoryCacheOptions());
             var cacheTime = TimeSpan.FromSeconds(123);
-            object expectedValue;
-            cache.Setup(c => c.TryGetValue(this.url, out expectedValue)).Returns(false);
-            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+            var client = new System.Net.Http.HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache));
 
             // execute
             var result = await client.GetAsync(this.url);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,8 +25,8 @@ variables:
   solution: 'HttpClient.Caching.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  majorVersion: 1
-  minorVersion: 6
+  majorVersion: 2
+  minorVersion: 0
   patchVersion: $[counter(format('{0}.{1}', variables.majorVersion, variables.minorVersion), 0)]
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     # Versioning: 1.0.0

--- a/docs/inmemory-nuget-feasibility.md
+++ b/docs/inmemory-nuget-feasibility.md
@@ -1,0 +1,59 @@
+# Feasibility: replace copied `Microsoft.Extensions.Caching.InMemory` code with NuGet package
+
+## Short answer
+A **full replacement is not possible without changing target frameworks**. The project targets `netstandard1.2`, while `Microsoft.Extensions.Caching.Memory` 10.0.5 targets `.NET Standard 2.0` and `.NET Framework 4.6.2` (or newer), not `netstandard1.2`.
+
+## What about `Count` and `Clear` specifically?
+Yes, a NuGet-based replacement would still help:
+
+- `Count` and `Clear` **exist on the concrete** `Microsoft.Extensions.Caching.Memory.MemoryCache` type.
+- `Count` and `Clear` **do not exist on** `IMemoryCache` (interface).
+
+So these members can be substituted, but you need one of these approaches:
+1. Use `MemoryCache` (concrete type) at call sites that need `Count`/`Clear`.
+2. Keep code typed as `IMemoryCache` and add a small adapter/extension that performs a safe cast to `MemoryCache` when available.
+
+## Evidence in this repository
+- The library currently multi-targets: `net48;netstandard1.2;netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0`.
+- The project sets `RootNamespace` to `Microsoft.Extensions.Caching` and contains local copies of `Abstractions` and `InMemory` APIs.
+- Internal handlers (`InMemoryCacheHandler`, `InMemoryCacheFallbackHandler`) directly depend on the copied `IMemoryCache` abstraction and extension helpers in this repository.
+
+## External package compatibility check
+- NuGet package `Microsoft.Extensions.Caching.Memory` 10.0.5 supports `netstandard2.0` / `net462+`, not `netstandard1.2`.
+- Microsoft Learn API docs show `MemoryCache.Count` and `MemoryCache.Clear()` on the concrete type.
+- Microsoft Learn API docs for `IMemoryCache` show methods like `TryGetValue`, `CreateEntry`, `Remove` and do not list `Count`/`Clear`.
+
+## Migration options
+
+### Option A (recommended): Keep `netstandard1.2` support (hybrid)
+1. Keep copied implementation only for `netstandard1.2`.
+2. For other TFMs, reference:
+   - `Microsoft.Extensions.Caching.Memory`
+   - `Microsoft.Extensions.Caching.Abstractions`
+   - `Microsoft.Extensions.Primitives`
+3. Add a tiny helper for `Count`/`Clear` (cast to concrete `MemoryCache` when possible).
+
+Pros:
+- No breaking TFM change.
+- You still gain value from official package on modern frameworks.
+
+Cons:
+- Dual-path maintenance complexity.
+
+### Option B: Full replacement with official packages
+1. Drop `netstandard1.2` from targets.
+2. Remove copied abstractions/in-memory files.
+3. Refactor type usage to official APIs (e.g., `IChangeToken` from `Microsoft.Extensions.Primitives`).
+4. Decide how to expose `Count`/`Clear` (concrete type or wrapper abstraction).
+
+Pros:
+- Removes forked cache maintenance.
+- Aligns with current Microsoft behavior.
+
+Cons:
+- Breaking change for consumers requiring `netstandard1.2`.
+
+## Recommendation
+If backward compatibility matters, do Option A now. If not, do Option B in a major release.
+
+Either way, **`Count` and `Clear` are not blockers** by themselves; the main blocker is `netstandard1.2`.


### PR DESCRIPTION
### Motivation

- Allow using concrete `MemoryCache` (instead of `IMemoryCache`) so callers can access concrete members and provide configuration via `MemoryCacheOptions`.
- Make cache construction configurable at handler creation time and simplify unit testing by using a real `MemoryCache` instance.
- Document feasibility of replacing the copied InMemory implementation with the official NuGet package and bump package versioning for a breaking change release.

### Description

- Switched internal cache fields and constructor parameters from `IMemoryCache` to `MemoryCache` in `InMemoryCacheHandler` and `InMemoryCacheFallbackHandler` and default to `new MemoryCache(memoryCacheOptions ?? new MemoryCacheOptions())` when options are provided or omitted.
- Added an optional `MemoryCacheOptions memoryCacheOptions` parameter to the public constructors so callers can customize cache behavior.
- Updated tests in `Tests/HttpClient.Caching.Tests/InMemory/InMemoryCacheFallbackHandlerTests.cs` to remove `Moq` usage and instantiate `MemoryCache` directly, and adapted assertions to inspect the concrete cache state.
- Added `docs/inmemory-nuget-feasibility.md` describing migration options and constraints for replacing the copied `InMemory` code with `Microsoft.Extensions.Caching.Memory` from NuGet.
- Bumped `majorVersion`/`minorVersion` in `azure-pipelines.yml` to `2.0` to reflect the breaking change.

### Testing

- Ran unit tests with `dotnet test` for the `HttpClient.Caching.Tests` project, and the modified in-memory cache tests (`InMemoryCacheFallbackHandlerTests`) passed.
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d374166cc083229a86d750bb069153)